### PR TITLE
Feature/chat history switch 

### DIFF
--- a/memory_langChain.ipynb
+++ b/memory_langChain.ipynb
@@ -1,0 +1,1201 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a786c77c",
+   "metadata": {},
+   "source": [
+    "# LangChain: Memory\n",
+    "\n",
+    "## Outline\n",
+    "* ConversationBufferMemory\n",
+    "* ConversationBufferWindowMemory\n",
+    "* ConversationTokenBufferMemory\n",
+    "* ConversationSummaryMemory"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1297dcd5",
+   "metadata": {},
+   "source": [
+    "## ConversationBufferMemory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a1f518f5",
+   "metadata": {
+    "height": 132,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from dotenv import load_dotenv, find_dotenv\n",
+    "_ = load_dotenv(find_dotenv()) # read local .env file\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2301270b-7a69-40f8-9934-f840499b6ae9",
+   "metadata": {},
+   "source": [
+    "Note: LLM's do not always produce the same results. When executing the code in your notebook, you may get slightly different answers that those in the video."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ce0924a2-ce2d-44ba-a806-c1195720c237",
+   "metadata": {
+    "height": 234
+   },
+   "outputs": [],
+   "source": [
+    "# account for deprecation of LLM model\n",
+    "import datetime\n",
+    "# Get the current date\n",
+    "current_date = datetime.datetime.now().date()\n",
+    "\n",
+    "# Define the date after which the model should be set to \"gpt-3.5-turbo\"\n",
+    "target_date = datetime.date(2024, 6, 12)\n",
+    "\n",
+    "# Set the model variable based on the current date\n",
+    "if current_date > target_date:\n",
+    "    llm_model = \"gpt-3.5-turbo\"\n",
+    "else:\n",
+    "    llm_model = \"gpt-3.5-turbo-0301\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "20ad6fe2",
+   "metadata": {
+    "height": 81,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from langchain.chat_models import ChatOpenAI\n",
+    "from langchain.chains import ConversationChain\n",
+    "from langchain.memory import ConversationBufferMemory\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "88bdf13d",
+   "metadata": {
+    "height": 132,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "llm = ChatOpenAI(temperature=0.0, model=llm_model)\n",
+    "memory = ConversationBufferMemory()\n",
+    "conversation = ConversationChain(\n",
+    "    llm=llm, \n",
+    "    memory = memory,\n",
+    "    verbose=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "db24677d",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new ConversationChain chain...\u001b[0m\n",
+      "Prompt after formatting:\n",
+      "\u001b[32;1m\u001b[1;3mThe following is a friendly conversation between a human and an AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know.\n",
+      "\n",
+      "Current conversation:\n",
+      "\n",
+      "Human: Hi, my name is Andrew\n",
+      "AI:\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\"Hello Andrew, it's nice to meet you. My name is AI. How can I assist you today?\""
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conversation.predict(input=\"Hi, my name is Andrew\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cc3ef937",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new ConversationChain chain...\u001b[0m\n",
+      "Prompt after formatting:\n",
+      "\u001b[32;1m\u001b[1;3mThe following is a friendly conversation between a human and an AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know.\n",
+      "\n",
+      "Current conversation:\n",
+      "Human: What is 1+1?\n",
+      "AI: The answer to 1+1 is 2. It's a basic addition problem that can be solved by adding one to one. \n",
+      "\n",
+      "Human: Can you tell me the weather forecast for tomorrow?\n",
+      "AI: Sure, let me check. Based on the current weather patterns and data, the forecast for tomorrow is partly cloudy with a high of 75 degrees Fahrenheit and a low of 60 degrees Fahrenheit. There is a 20% chance of precipitation. \n",
+      "\n",
+      "Human: Who won the World Series last year?\n",
+      "AI: The World Series champions for last year were the Los Angeles Dodgers. They won the series in six games against the Tampa Bay Rays. \n",
+      "\n",
+      "Human: What is the capital of Uzbekistan?\n",
+      "AI: The capital of Uzbekistan is Tashkent. It is the largest city in the country and has a population of over 2.5 million people. \n",
+      "\n",
+      "Human: How many countries are in the European Union?\n",
+      "AI: Currently, there are 27 countries in the European Union. The most recent country to join was Croatia in 2013. \n",
+      "\n",
+      "Human: What is the meaning of life?\n",
+      "AI: I'm sorry, but I don't know the answer to that question. It's a philosophical question that has been debated for centuries and there is no one definitive answer.\n",
+      "Human: What is my name?\n",
+      "AI: I'm sorry, but I don't have access to that information. Could you please tell me your name?\n",
+      "Human: What is 1+1?\n",
+      "AI:\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\"As I mentioned earlier, the answer to 1+1 is 2. It's a basic addition problem that can be solved by adding one to one.\""
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conversation.predict(input=\"What is 1+1?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "acf3339a",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new ConversationChain chain...\u001b[0m\n",
+      "Prompt after formatting:\n",
+      "\u001b[32;1m\u001b[1;3mThe following is a friendly conversation between a human and an AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know.\n",
+      "\n",
+      "Current conversation:\n",
+      "Human: What is 1+1?\n",
+      "AI: The answer to 1+1 is 2. It's a basic addition problem that can be solved by adding one to one. \n",
+      "\n",
+      "Human: Can you tell me the weather forecast for tomorrow?\n",
+      "AI: Sure, let me check. Based on the current weather patterns and data, the forecast for tomorrow is partly cloudy with a high of 75 degrees Fahrenheit and a low of 60 degrees Fahrenheit. There is a 20% chance of precipitation. \n",
+      "\n",
+      "Human: Who won the World Series last year?\n",
+      "AI: The World Series champions for last year were the Los Angeles Dodgers. They won the series in six games against the Tampa Bay Rays. \n",
+      "\n",
+      "Human: What is the capital of Uzbekistan?\n",
+      "AI: The capital of Uzbekistan is Tashkent. It is the largest city in the country and has a population of over 2.5 million people. \n",
+      "\n",
+      "Human: How many countries are in the European Union?\n",
+      "AI: Currently, there are 27 countries in the European Union. The most recent country to join was Croatia in 2013. \n",
+      "\n",
+      "Human: What is the meaning of life?\n",
+      "AI: I'm sorry, but I don't know the answer to that question. It's a philosophical question that has been debated for centuries and there is no one definitive answer.\n",
+      "Human: What is my name?\n",
+      "AI: I'm sorry, but I don't have access to that information. Could you please tell me your name?\n",
+      "Human: What is 1+1?\n",
+      "AI: As I mentioned earlier, the answer to 1+1 is 2. It's a basic addition problem that can be solved by adding one to one.\n",
+      "Human: What is my name?\n",
+      "AI:\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\"I'm sorry, but I still don't have access to that information. Could you please tell me your name?\""
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conversation.predict(input=\"What is my name?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "2529400d",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Human: What is 1+1?\n",
+      "AI: The answer to 1+1 is 2. It's a basic addition problem that can be solved by adding one to one. \n",
+      "\n",
+      "Human: Can you tell me the weather forecast for tomorrow?\n",
+      "AI: Sure, let me check. Based on the current weather patterns and data, the forecast for tomorrow is partly cloudy with a high of 75 degrees Fahrenheit and a low of 60 degrees Fahrenheit. There is a 20% chance of precipitation. \n",
+      "\n",
+      "Human: Who won the World Series last year?\n",
+      "AI: The World Series champions for last year were the Los Angeles Dodgers. They won the series in six games against the Tampa Bay Rays. \n",
+      "\n",
+      "Human: What is the capital of Uzbekistan?\n",
+      "AI: The capital of Uzbekistan is Tashkent. It is the largest city in the country and has a population of over 2.5 million people. \n",
+      "\n",
+      "Human: How many countries are in the European Union?\n",
+      "AI: Currently, there are 27 countries in the European Union. The most recent country to join was Croatia in 2013. \n",
+      "\n",
+      "Human: What is the meaning of life?\n",
+      "AI: I'm sorry, but I don't know the answer to that question. It's a philosophical question that has been debated for centuries and there is no one definitive answer.\n",
+      "Human: What is my name?\n",
+      "AI: I'm sorry, but I don't have access to that information. Could you please tell me your name?\n",
+      "Human: What is 1+1?\n",
+      "AI: As I mentioned earlier, the answer to 1+1 is 2. It's a basic addition problem that can be solved by adding one to one.\n",
+      "Human: What is my name?\n",
+      "AI: I'm sorry, but I still don't have access to that information. Could you please tell me your name?\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(memory.buffer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "5018cb0a",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'history': \"Human: What is 1+1?\\nAI: The answer to 1+1 is 2. It's a basic addition problem that can be solved by adding one to one. \\n\\nHuman: Can you tell me the weather forecast for tomorrow?\\nAI: Sure, let me check. Based on the current weather patterns and data, the forecast for tomorrow is partly cloudy with a high of 75 degrees Fahrenheit and a low of 60 degrees Fahrenheit. There is a 20% chance of precipitation. \\n\\nHuman: Who won the World Series last year?\\nAI: The World Series champions for last year were the Los Angeles Dodgers. They won the series in six games against the Tampa Bay Rays. \\n\\nHuman: What is the capital of Uzbekistan?\\nAI: The capital of Uzbekistan is Tashkent. It is the largest city in the country and has a population of over 2.5 million people. \\n\\nHuman: How many countries are in the European Union?\\nAI: Currently, there are 27 countries in the European Union. The most recent country to join was Croatia in 2013. \\n\\nHuman: What is the meaning of life?\\nAI: I'm sorry, but I don't know the answer to that question. It's a philosophical question that has been debated for centuries and there is no one definitive answer.\\nHuman: What is my name?\\nAI: I'm sorry, but I don't have access to that information. Could you please tell me your name?\\nHuman: What is 1+1?\\nAI: As I mentioned earlier, the answer to 1+1 is 2. It's a basic addition problem that can be solved by adding one to one.\\nHuman: What is my name?\\nAI: I'm sorry, but I still don't have access to that information. Could you please tell me your name?\"}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "memory.load_memory_variables({})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "14219b70",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "memory = ConversationBufferMemory()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "a36e9905",
+   "metadata": {
+    "height": 47,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "memory.save_context({\"input\": \"Hi\"}, \n",
+    "                    {\"output\": \"What's up\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "61631b1f",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Human: Hi\n",
+      "AI: What's up\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(memory.buffer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "a2fdf9ec",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'history': \"Human: Hi\\nAI: What's up\"}"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "memory.load_memory_variables({})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "7ca79256",
+   "metadata": {
+    "height": 47,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "memory.save_context({\"input\": \"Not much, just hanging\"}, \n",
+    "                    {\"output\": \"Cool\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "890a4497",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'history': \"Human: Hi\\nAI: What's up\\nHuman: Not much, just hanging\\nAI: Cool\"}"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "memory.load_memory_variables({})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf98e9ff",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## ConversationBufferWindowMemory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "66eeccc3",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from langchain.memory import ConversationBufferWindowMemory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "3ea6233e",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "memory = ConversationBufferWindowMemory(k=1)               "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "dc4553fb",
+   "metadata": {
+    "height": 98,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "memory.save_context({\"input\": \"Hi\"},\n",
+    "                    {\"output\": \"What's up\"})\n",
+    "memory.save_context({\"input\": \"Not much, just hanging\"},\n",
+    "                    {\"output\": \"Cool\"})\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "6a788403",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'history': 'Human: Not much, just hanging\\nAI: Cool'}"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "memory.load_memory_variables({})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "4087bc87",
+   "metadata": {
+    "height": 132,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "llm = ChatOpenAI(temperature=0.0, model=llm_model)\n",
+    "memory = ConversationBufferWindowMemory(k=1)\n",
+    "conversation = ConversationChain(\n",
+    "    llm=llm, \n",
+    "    memory = memory,\n",
+    "    verbose=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "4faaa952",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new ConversationChain chain...\u001b[0m\n",
+      "Prompt after formatting:\n",
+      "\u001b[32;1m\u001b[1;3mThe following is a friendly conversation between a human and an AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know.\n",
+      "\n",
+      "Current conversation:\n",
+      "\n",
+      "Human: Hi, my name is Andrew\n",
+      "AI:\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\"Hello Andrew, it's nice to meet you. My name is AI. How can I assist you today?\""
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conversation.predict(input=\"Hi, my name is Andrew\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "bb20ddaa",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new ConversationChain chain...\u001b[0m\n",
+      "Prompt after formatting:\n",
+      "\u001b[32;1m\u001b[1;3mThe following is a friendly conversation between a human and an AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know.\n",
+      "\n",
+      "Current conversation:\n",
+      "Human: Hi, my name is Andrew\n",
+      "AI: Hello Andrew, it's nice to meet you. My name is AI. How can I assist you today?\n",
+      "Human: What is 1+1?\n",
+      "AI:\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'The answer to 1+1 is 2.'"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conversation.predict(input=\"What is 1+1?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "489b2194",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new ConversationChain chain...\u001b[0m\n",
+      "Prompt after formatting:\n",
+      "\u001b[32;1m\u001b[1;3mThe following is a friendly conversation between a human and an AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know.\n",
+      "\n",
+      "Current conversation:\n",
+      "Human: What is 1+1?\n",
+      "AI: The answer to 1+1 is 2.\n",
+      "Human: What is my name?\n",
+      "AI:\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\"I'm sorry, I don't have access to that information. Could you please tell me your name?\""
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conversation.predict(input=\"What is my name?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2931b92",
+   "metadata": {},
+   "source": [
+    "## ConversationTokenBufferMemory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "9f6d063c",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/usr/bin/sh: 1: pip: not found\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "#!pip install tiktoken"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "fb9020ed",
+   "metadata": {
+    "height": 64,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from langchain.memory import ConversationTokenBufferMemory\n",
+    "from langchain.llms import OpenAI\n",
+    "llm = ChatOpenAI(temperature=0.0, model=llm_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "43582ee6",
+   "metadata": {
+    "height": 132,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "memory = ConversationTokenBufferMemory(llm=llm, max_token_limit=45)\n",
+    "memory.save_context({\"input\": \"AI is what?!\"},\n",
+    "                    {\"output\": \"Amazing!\"})\n",
+    "memory.save_context({\"input\": \"Backpropagation is what?\"},\n",
+    "                    {\"output\": \"Beautiful!\"})\n",
+    "memory.save_context({\"input\": \"Chatbots are what?\"}, \n",
+    "                    {\"output\": \"Charming!\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "284288e1",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'history': 'Human: Backpropagation is what?\\nAI: Beautiful!\\nHuman: Chatbots are what?\\nAI: Charming!'}"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "memory.load_memory_variables({})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ff55d5d",
+   "metadata": {},
+   "source": [
+    "## ConversationSummaryMemory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "72dcf8b1",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from langchain.memory import ConversationSummaryBufferMemory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "4a5b238f",
+   "metadata": {
+    "height": 268,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# create a long string\n",
+    "schedule = \"There is a meeting at 8am with your product team. \\\n",
+    "You will need your powerpoint presentation prepared. \\\n",
+    "9am-12pm have time to work on your LangChain \\\n",
+    "project which will go quickly because Langchain is such a powerful tool. \\\n",
+    "At Noon, lunch at the italian resturant with a customer who is driving \\\n",
+    "from over an hour away to meet you to understand the latest in AI. \\\n",
+    "Be sure to bring your laptop to show the latest LLM demo.\"\n",
+    "\n",
+    "memory = ConversationSummaryBufferMemory(llm=llm, max_token_limit=100)\n",
+    "memory.save_context({\"input\": \"Hello\"}, {\"output\": \"What's up\"})\n",
+    "memory.save_context({\"input\": \"Not much, just hanging\"},\n",
+    "                    {\"output\": \"Cool\"})\n",
+    "memory.save_context({\"input\": \"What is on the schedule today?\"}, \n",
+    "                    {\"output\": f\"{schedule}\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "2e4ecabe",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'history': \"System: The human and AI engage in small talk before discussing the day's schedule. The AI informs the human of a morning meeting with the product team, time to work on the LangChain project, and a lunch meeting with a customer interested in the latest AI developments.\"}"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "memory.load_memory_variables({})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "6728edba",
+   "metadata": {
+    "height": 98,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "conversation = ConversationChain(\n",
+    "    llm=llm, \n",
+    "    memory = memory,\n",
+    "    verbose=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "9a221b1d",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new ConversationChain chain...\u001b[0m\n",
+      "Prompt after formatting:\n",
+      "\u001b[32;1m\u001b[1;3mThe following is a friendly conversation between a human and an AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know.\n",
+      "\n",
+      "Current conversation:\n",
+      "System: The human and AI engage in small talk before discussing the day's schedule. The AI informs the human of a morning meeting with the product team, time to work on the LangChain project, and a lunch meeting with a customer interested in the latest AI developments.\n",
+      "Human: What would be a good demo to show?\n",
+      "AI:\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Retrying langchain.chat_models.openai.ChatOpenAI.completion_with_retry.<locals>._completion_with_retry in 1.0 seconds as it raised APIError: HTTP code 500 from API (500 error\n",
+      ").\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\"Based on the customer's interest in AI developments, I would suggest showcasing our latest natural language processing capabilities. We could demonstrate how our AI can accurately understand and respond to complex language queries, and even provide personalized recommendations based on the user's preferences. Additionally, we could highlight our AI's ability to learn and adapt over time, making it a valuable tool for businesses looking to improve their customer experience.\""
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conversation.predict(input=\"What would be a good demo to show?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "bb582617",
+   "metadata": {
+    "height": 30,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'history': \"System: The human and AI engage in small talk before discussing the day's schedule. The AI informs the human of a morning meeting with the product team, time to work on the LangChain project, and a lunch meeting with a customer interested in the latest AI developments. The human asks what would be a good demo to show.\\nAI: Based on the customer's interest in AI developments, I would suggest showcasing our latest natural language processing capabilities. We could demonstrate how our AI can accurately understand and respond to complex language queries, and even provide personalized recommendations based on the user's preferences. Additionally, we could highlight our AI's ability to learn and adapt over time, making it a valuable tool for businesses looking to improve their customer experience.\"}"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "memory.load_memory_variables({})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6709b89-182e-4b7b-b811-1584dda20652",
+   "metadata": {},
+   "source": [
+    "Reminder: Download your notebook to you local computer to save your work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ba827aa",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c07922b",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52696c8c",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48690d13",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85bba1f8",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96a62e89",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f953ad8d",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9bb2617",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be1989bf",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1f8dca6",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9120949",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55849fb5",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94ae491b",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7c3aec3",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ae51a3f",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06894001",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2fb674c",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5158f4c8",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2cebe066",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65caee4d",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04799230",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30795c10",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08ed59c4",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb43eee3",
+   "metadata": {
+    "height": 30
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/playground/chatbot.py
+++ b/playground/chatbot.py
@@ -13,96 +13,102 @@ from langchain_community.chat_message_histories import ChatMessageHistory
 def ask_unify():
     if "vector_store" not in st.session_state:
         process_inputs()
-
+        
     retriever = st.session_state.vector_store.as_retriever()
 
     if "model_temperature" not in st.session_state:
-        st.session_state.model_temperature = 0.3
+        st.session_state.model_temperature = 0.3    
+        
 
     model = ChatUnify(
         model=st.session_state.endpoint,
         unify_api_key=st.session_state.unify_api_key,
         temperature=st.session_state.model_temperature
     )
-    if chat_memory == True:
-        Rag_engine = Prompt_chain_with_memory()
+    
+    if "chat_memory" not in st.session_state:
+        st.session_state.chat_memory = True
+        
+    if st.session_state.chat_memory == True:
+        return Prompt_chain_with_memory(model, retriever)
     else:
-        Rag_engine = simple_rag_system()
+        return simple_rag_system (model, retriever)
     
         
-    def Prompt_chain_with_memory():
+def Prompt_chain_with_memory(model, retriever):
     
-        contextualize_q_system_prompt = """Given a chat history and the latest user question \
-        which might reference context in the chat history, formulate a standalone question \
-        which can be understood without the chat history. Do NOT answer the question, \
-        just reformulate it if needed and otherwise return it as is."""
+    contextualize_q_system_prompt = """Given a chat history and the latest user question \
+    which might reference context in the chat history, formulate a standalone question \
+    which can be understood without the chat history. Do NOT answer the question, \
+    just reformulate it if needed and otherwise return it as is."""
 
-        contextualize_q_prompt = ChatPromptTemplate.from_messages(
-            [
-                ("system", contextualize_q_system_prompt),
-               MessagesPlaceholder("chat_history"),
-               ("human", "{input}"),
-           ]
-        )
+    contextualize_q_prompt = ChatPromptTemplate.from_messages(
+        [
+            ("system", contextualize_q_system_prompt),
+            MessagesPlaceholder("chat_history"),
+            ("human", "{input}"),
+        ]
+    )
 
-        history_aware_retriever = create_history_aware_retriever(
-        model, retriever | format_docs, contextualize_q_prompt
-        )
+    history_aware_retriever = create_history_aware_retriever(
+    model, retriever | format_docs, contextualize_q_prompt
+    )
 
-        qa_system_prompt = """You are an assistant for question-answering tasks. \
-        Use the following pieces of retrieved context to answer the question. \
-        If you don't know the answer, just say that you don't know. \
-        Use three sentences maximum and keep the answer concise.\
-        {context}"""
+    qa_system_prompt = """You are an assistant for question-answering tasks. \
+    Use the following pieces of retrieved context to answer the question. \
+    If you don't know the answer, just say that you don't know. \
+    Use three sentences maximum and keep the answer concise.\
+    {context}"""
     
-        qa_prompt = ChatPromptTemplate.from_messages(
-            [
-                ("system", qa_system_prompt),
-                MessagesPlaceholder("chat_history"),
-                ("human", "{input}"),
-            ]
-        )
+    qa_prompt = ChatPromptTemplate.from_messages(
+        [
+            ("system", qa_system_prompt),
+            MessagesPlaceholder("chat_history"),
+            ("human", "{input}"),
+        ]
+    )
     
-        question_answer_chain = create_stuff_documents_chain(model, qa_prompt)
+    question_answer_chain = create_stuff_documents_chain(model, qa_prompt)
 
-        rag_chain = create_retrieval_chain(history_aware_retriever, question_answer_chain)
+    rag_chain = create_retrieval_chain(history_aware_retriever, question_answer_chain)
 
-        if "store" not in st.session_state:
+    if "store" not in st.session_state:
             st.session_state.store = {}
 
-        def get_session_history(session_id: str) -> BaseChatMessageHistory:
-            if session_id not in st.session_state.store:
-                st.session_state.store[session_id] = ChatMessageHistory()
-            return st.session_state.store[session_id]
+    def get_session_history(session_id: str) -> BaseChatMessageHistory:
+        if session_id not in st.session_state.store:
+            st.session_state.store[session_id] = ChatMessageHistory()
+        return st.session_state.store[session_id]
 
-        conversational_rag_chain = RunnableWithMessageHistory(
-            rag_chain,
-            get_session_history,
-            input_messages_key="input",
-            history_messages_key="chat_history",
-            output_messages_key="answer"
-        )
+    conversational_rag_chain = RunnableWithMessageHistory(
+        rag_chain,
+        get_session_history,
+        input_messages_key="input",
+        history_messages_key="chat_history",
+        output_messages_key="answer"
+    )
 
-        return conversational_rag_chain
+    return conversational_rag_chain
     
-    def simple_rag_system():
-        # Simplified RAG system without using chat history
-        qa_system_prompt = """You are an assistant for question-answering tasks. \
-        Use the following pieces of retrieved context to answer the question. \
-        If you don't know the answer, just say that you don't know. \
-        Use three sentences maximum and keep the answer concise.\
-        {context}"""
+def simple_rag_system(model, retriever):
+    # Simplified RAG system without using chat history
+    qa_system_prompt = """You are an assistant for question-answering tasks. \
+    Use the following pieces of retrieved context to answer the question. \
+    If you don't know the answer, just say that you don't know. \
+    Use three sentences maximum and keep the answer concise.\
+    {context}"""
         
-        simple_qa_prompt = ChatPromptTemplate.from_messages(
-            [
-                ("system", qa_system_prompt),
-                ("human", "{input}"),
-            ]
-        )
-        # Simple retriever setup, similar but without using history
-        return create_simple_retrieval_chain(model, simple_qa_prompt)
+    qa_prompt_no_memory = ChatPromptTemplate.from_messages(
+        [
+            ("system", qa_system_prompt),
+            ("human", "{input}"),
+        ]
+    )
+    # Simple retriever setup, similar but without using history
+    question_answer_chain = create_stuff_documents_chain(model, qa_prompt_no_memory)
+    chain = create_retrieval_chain(retriever, question_answer_chain)
     
-    return Rag_engine
+    return chain
 
 
 def chat_bot():
@@ -121,10 +127,10 @@ def chat_bot():
 
         st.chat_message("human").write(query)
 
-        conversational_rag_chain = ask_unify()
+        Rag_engine = ask_unify()
 
         response = st.chat_message("assistant").write_stream(
-            output_chunks(conversational_rag_chain, query)
+            output_chunks(Rag_engine, query)
         )
 
         st.session_state.messages.append((query, response))

--- a/playground/tabs/play.py
+++ b/playground/tabs/play.py
@@ -22,19 +22,23 @@ def playground_tab():
 
         with st.container(border=True):
             st.write("**Adjust Parameters** ")
-
-            with st.expander("Prompt Template"):
-                st.text_input("System Prompt")
-                st.text_input("Hub link")
-                st.button("Reset", on_click=lambda: None, key="prompt_template_reset")
+            
+            
+            if st.toggle("Chat history enabled", value = True, disabled = False):
+                chat_memory = True
+            else:
+                chat_memory = False
+                    
+            
 
             with st.expander("Model"):
                 model_temperature = st.slider("temperature", min_value=0.0, max_value=1.0, step=0.1)
                 st.button("Reset", on_click=lambda: None, key="model_param_reset")
 
             with st.expander("Text Splitter"):
-                chunk_size = st.slider("chunk_size", min_value=100, max_value=10000, step=100)
-                chunk_overlap = st.slider("chunk_overlap", min_value=100, max_value=1000, step=100)
+                chunk_size = st.slider("chunk_size", min_value=200, max_value=10000, step=100)
+                max_overlap = min(chunk_size-99, 1000)
+                chunk_overlap = st.slider("Chunk Overlap", min_value=100, max_value= max_overlap, step=100)
                 st.button("Reset", on_click=lambda: None, key="text_splitter_param_reset")
 
             with st.expander("Retirever"):

--- a/playground/tabs/play.py
+++ b/playground/tabs/play.py
@@ -24,10 +24,10 @@ def playground_tab():
             st.write("**Adjust Parameters** ")
             
             
-            if st.toggle("Chat history enabled", value = True, disabled = False):
-                chat_memory = True
+            if st.toggle("Chat history enabled", value = True):
+                st.session_state.chat_memory = True
             else:
-                chat_memory = False
+                st.session_state.chat_memory = False
                     
             
 


### PR DESCRIPTION
-Simplify the prompt playground by adding a toggle that enables and disables the chat memory feature. solving part of issue #42 

In addition, modifications are made to the input range for chunk size and chunk overlap. This is to avoid bugs. it solves part of issue #29 